### PR TITLE
from upstream: Xnamespace: fix wrong const char* authProto

### DIFF
--- a/Xext/namespace/namespace.h
+++ b/Xext/namespace/namespace.h
@@ -12,7 +12,7 @@
 
 struct auth_token {
     struct xorg_list entry;
-    const char *authProto;
+    char *authProto;
     char *authTokenData;
     size_t authTokenLen;
     XID authId;


### PR DESCRIPTION
The authProto field always is assigned to dynamically allocated buffer (strdup()'ed) and needs to be freed sometimes, so cannot be const.