### PR TITLE
Xext: xv: fix redefinition of typedef 'XvPortNotifyPtr'

### DIFF
--- a/Xext/xvdix_priv.h
+++ b/Xext/xvdix_priv.h
@@ -28,7 +28,7 @@ typedef struct _XvPortNotifyRec {
     struct _XvPortNotifyRec *next;
     ClientPtr client;
     unsigned long id;
-} XvPortNotifyRec, *XvPortNotifyPtr;
+} XvPortNotifyRec;
 
 extern int XvReqCode;
 extern int XvErrorBase;


### PR DESCRIPTION
  In file included from ../Xext/xvmc.c:14:
  ../Xext/xvdix_priv.h:31:21: warning: redefinition of typedef 'XvPortNotifyPtr' is a C11 feature [-Wtypedef-redefinition]
     31 | } XvPortNotifyRec, *XvPortNotifyPtr;
        |                     ^
  ../Xext/xvdix.h:73:34: note: previous definition is here
     73 | typedef struct _XvPortNotifyRec *XvPortNotifyPtr;
        |                                  ^
  1 warning generated.