### PR TITLE
dixfonts.c: Overflow warning fix

### DIFF
--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -73,6 +73,7 @@ Equipment Corporation.
 #include "closestr.h"
 #include "dixfont.h"
 #include "xace.h"
+#include <limits.h>  // for SIZE_MAX
 
 #ifdef XF86BIGFONT
 #include "xf86bigfontsrv.h"
@@ -744,8 +745,13 @@ doListFontsAndAliases(ClientPtr client, LFclosurePtr c)
         .nFonts = nnames,
         .sequenceNumber = client->sequence
     };
-
-    char *bufferStart = calloc(1, rep.length << 2);
+	
+    size_t bufsize = (size_t)rep.length << 2;
+    if (rep.length > (SIZE_MAX >> 2)) {
+	SendErrorToClient(client, X_ListFonts, 0, 0, BadAlloc);
+	goto bail;
+    }
+    char *bufferStart = calloc(1, bufsize);
     char *bufptr = bufferStart;
 
     if (!bufptr && rep.length) {


### PR DESCRIPTION
../dix/dixfonts.c: In function ‘doListFontsAndAliases’:
../dix/dixfonts.c:748:25: warning: argument 2 range [2147483648, 4294967295] exceeds maximum object size 2147483647 [-Walloc-size-larger-than=]
  748 |     char *bufferStart = calloc(1, rep.length << 2);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../include/os.h:53,
                 from ../include/misc.h:126,
                 from ../include/cursor.h:50,
                 from ../dix/input_priv.h:54,
                 from ../dix/dix_priv.h:20,
                 from ../dix/dixfonts.c:60:
/usr/share/mingw-w64/include/stdlib.h:536:17: note: in a call to allocation function ‘calloc’ declared here
  536 |   void *__cdecl calloc(size_t _NumOfElements,size_t _SizeOfElements);
      |                 ^~~~~~